### PR TITLE
Improve performance

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -327,7 +327,7 @@ export default function Parser(options) {
           alias,
           name,
           attrs = {},
-          seenAttrs = {},
+          seenAttrs = new Set(),
           skipAttr,
           w,
           j;
@@ -467,12 +467,12 @@ export default function Parser(options) {
         }
 
         // check attribute re-declaration
-        if (name in seenAttrs) {
+        if (seenAttrs.has(name)) {
           handleWarning('attribute <' + name + '> already defined');
           continue;
         }
 
-        seenAttrs[name] = true;
+        seenAttrs.add(name);
 
         if (!isNamespace) {
           attrs[name] = value;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -25,6 +25,11 @@ function cloneNsMatrix(nsMatrix) {
   return clone;
 }
 
+// per-matrix element name cache; stored under a symbol so it is
+// invisible to the `for (key in nsMatrix)` clone above and gets
+// collected together with the matrix it belongs to
+var NAME_CACHE = Symbol('nameCache');
+
 function uriPrefix(prefix) {
   return prefix + '$uri';
 }
@@ -251,7 +256,9 @@ export default function Parser(options) {
    * @param  {string} xml
    */
   function parse(xml) {
-    var nsMatrixStack = isNamespace ? [] : null,
+    var elNameCache = null,
+        elNameCacheMatrix = null,
+        nsMatrixStack = isNamespace ? [] : null,
         nsMatrix = isNamespace ? buildNsMatrix(nsUriToPrefix) : null,
         _nsMatrix,
         nodeStack = [],
@@ -912,30 +919,49 @@ export default function Parser(options) {
 
         _elementName = elementName;
 
-        w = elementName.indexOf(':');
-        if (w !== -1) {
-          xmlns = nsMatrix[elementName.substring(0, w)];
-
-          // prefix given; namespace must exist
-          if (!xmlns) {
-            return handleError('missing namespace on <' + _elementName + '>');
+        // memoize normalized names per namespace matrix; tag names
+        // typically repeat heavily and the matrix rarely changes.
+        if (elNameCacheMatrix !== nsMatrix) {
+          elNameCache = nsMatrix[NAME_CACHE];
+          if (elNameCache === undefined) {
+            elNameCache = nsMatrix[NAME_CACHE] = {};
           }
-
-          elementName = elementName.substr(w + 1);
-        } else {
-          xmlns = nsMatrix['xmlns'];
-
-          // if no default namespace is defined,
-          // we'll import the element as anonymous.
-          //
-          // it is up to users to correct that to the document defined
-          // targetNamespace, or whatever their undersanding of the
-          // XML spec mandates.
+          elNameCacheMatrix = nsMatrix;
         }
 
-        // adjust namespace prefixs as configured
-        if (xmlns) {
-          elementName = xmlns + ':' + elementName;
+        var _cachedName = elNameCache[elementName];
+
+        if (_cachedName !== undefined) {
+          elementName = _cachedName;
+        } else {
+
+          w = elementName.indexOf(':');
+          if (w !== -1) {
+            xmlns = nsMatrix[elementName.substring(0, w)];
+
+            // prefix given; namespace must exist
+            if (!xmlns) {
+              return handleError('missing namespace on <' + _elementName + '>');
+            }
+
+            elementName = elementName.substr(w + 1);
+          } else {
+            xmlns = nsMatrix['xmlns'];
+
+            // if no default namespace is defined,
+            // we'll import the element as anonymous.
+            //
+            // it is up to users to correct that to the document defined
+            // targetNamespace, or whatever their undersanding of the
+            // XML spec mandates.
+          }
+
+          // adjust namespace prefixs as configured
+          if (xmlns) {
+            elementName = xmlns + ':' + elementName;
+          }
+
+          elNameCache[_elementName] = elementName;
         }
 
       }


### PR DESCRIPTION
### What's inside

Speed up attributes seen check and cache tag parsing for a consistent performance boost:

#### Before

```
perf results: parse
╔═══════════════════════╤═════╤═════════╗
║ proxy                 │ 111 │ +12.61% ║
╟───────────────────────┼─────┼─────────╢
║ default               │ 97  │ +0%     ║
╟───────────────────────┼─────┼─────────╢
║ proxy + attrs         │ 207 │ +53.14% ║
╟───────────────────────┼─────┼─────────╢
║ default + attrs       │ 201 │ +51.74% ║
╟───────────────────────┼─────┼─────────╢
║ proxy / cached parser │ 210 │ +53.81% ║
╟───────────────────────┼─────┼─────────╢
║ proxy / full          │ 200 │ +51.5%  ║
╚═══════════════════════╧═════╧═════════╝
```


#### After

```
perf results: parse
╔═══════════════════════╤═════╤═════════╗
║ proxy                 │ 109 │ +14.68% ║
╟───────────────────────┼─────┼─────────╢
║ default               │ 93  │ +0%     ║
╟───────────────────────┼─────┼─────────╢
║ proxy + attrs         │ 185 │ +49.73% ║
╟───────────────────────┼─────┼─────────╢
║ default + attrs       │ 176 │ +47.16% ║
╟───────────────────────┼─────┼─────────╢
║ proxy / cached parser │ 188 │ +50.53% ║
╟───────────────────────┼─────┼─────────╢
║ proxy / full          │ 177 │ +47.46% ║
╚═══════════════════════╧═════╧═════════╝
```