### PR TITLE
Add ability to stream XML in chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [saxen](https://github.com/nikku/saxen) are documented he
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: support streaming XML in chunks via `Parser#write` and `Parser#end` ([#3](https://github.com/nikku/saxen/issues/3))
+
 ## 11.0.2
 
 * `CHORE`: mark as side-effect free

--- a/README.md
+++ b/README.md
@@ -122,6 +122,29 @@ parser.on('openTag', function(el) {
 ```
 
 
+## Streaming Mode
+
+Instead of parsing a complete document via `parse`, you may feed the parser XML in chunks via `write` and signal the end of the stream via `end`. This allows you to process huge documents in a memory efficient, step by step manner:
+
+```javascript
+const parser = new Parser();
+
+parser.on('openTag', function(name) { /* ... */ });
+
+parser
+  .write('<foo>')
+  .write('<bar />')
+  .write('</foo>')
+  .end();
+```
+
+Chunks may split anywhere, even in the middle of a tag, attribute, comment or CDATA section; the parser buffers the incomplete remainder until the next `write`. Parse events are emitted as soon as the corresponding token is complete. Calling `end` flushes the stream and reports an error (via the `error` hook and as the return value) if the buffered remainder is incomplete.
+
+The `write` / `end` pair mirrors Node's [writable stream](https://nodejs.org/api/stream.html#class-streamwritable) contract, making it straightforward to wire the parser up as a stream sink.
+
+__Note:__ In streaming mode the parse context (`line` / `column`) is relative to the currently buffered input rather than the whole document.
+
+
 ## Non-Features
 
 `/saxen/` lacks some features known in other XML parsers such as [sax-js](https://github.com/isaacs/sax-js):

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -84,6 +84,33 @@ export default function Parser(options) {
   var getContext = noopGetContext;
 
   /**
+   * Are we currently consuming a chunked stream of XML,
+   * i.e. is a `write` call in progress that may be followed
+   * by more chunks?
+   *
+   * @type {boolean}
+   */
+  var streaming = false;
+
+  /**
+   * Did we already encounter the root tag?
+   *
+   * Persisted across `write` calls so we can detect a missing
+   * start tag once the stream ends.
+   *
+   * @type {boolean}
+   */
+  var rootTagFound = false;
+
+  /**
+   * Not yet parsed remainder of the previously written chunk,
+   * i.e. an incomplete token that awaits more input.
+   *
+   * @type {string}
+   */
+  var leftoverXml = '';
+
+  /**
    * Do we need to parse the current elements attributes for namespaces?
    *
    * @type {boolean}
@@ -110,6 +137,13 @@ export default function Parser(options) {
    * @type {boolean}
    */
   var parseStop = false;
+
+  /**
+   * Namespace + node state shared across (streamed) parse runs.
+   */
+  var nsMatrixStack,
+      nsMatrix,
+      nodeStack;
 
   /**
    * A map of { uri: prefix } used by the parser.
@@ -222,7 +256,22 @@ export default function Parser(options) {
   };
 
   /**
-   * Parse xml string.
+   * Reset the parser state before a (streamed) parse run.
+   */
+  function resetState() {
+    nsMatrixStack = isNamespace ? [] : null;
+    nsMatrix = isNamespace ? buildNsMatrix(nsUriToPrefix) : null;
+    nodeStack = [];
+
+    getContext = noopGetContext;
+    parseStop = false;
+    returnError = null;
+    rootTagFound = false;
+    leftoverXml = '';
+  }
+
+  /**
+   * Parse a complete xml string.
    *
    * @param  {string} xml
    *
@@ -233,10 +282,68 @@ export default function Parser(options) {
       throw error('required args <xml=string>');
     }
 
-    returnError = null;
+    if (streaming) {
+      throw error('parse during stream; call end() first');
+    }
+
+    resetState();
 
     parse(xml);
 
+    getContext = noopGetContext;
+    parseStop = false;
+
+    return returnError;
+  };
+
+  /**
+   * Write the next chunk of a streamed xml string.
+   *
+   * Parse events are emitted for all complete tokens; an
+   * incomplete trailing token is buffered until the next
+   * `write` or, ultimately, reported as an error on `end`.
+   *
+   * @param  {string} xml
+   *
+   * @return {Parser} self
+   */
+  this['write'] = function(xml) {
+    if (typeof xml !== 'string') {
+      throw error('required args <xml=string>');
+    }
+
+    if (!streaming) {
+      resetState();
+      streaming = true;
+    }
+
+    if (!returnError) {
+      leftoverXml = parse(leftoverXml + xml, true) || '';
+    }
+
+    return this;
+  };
+
+  /**
+   * Finish parsing a streamed xml string, i.e. signal that
+   * no more chunks will be written.
+   *
+   * @return {Error} returnError, if not thrown
+   */
+  this['end'] = function() {
+    if (!streaming) {
+      resetState();
+    }
+
+    // flush the buffered remainder, now treating an incomplete
+    // trailing token as a hard error
+    streaming = false;
+
+    if (!returnError) {
+      parse(leftoverXml);
+    }
+
+    leftoverXml = '';
     getContext = noopGetContext;
     parseStop = false;
 
@@ -253,15 +360,26 @@ export default function Parser(options) {
   /**
    * Parse string, invoking configured listeners on element.
    *
-   * @param  {string} xml
+   * Namespace and node stack state is shared across (streamed)
+   * invocations via the enclosing parser scope.
+   *
+   * Internal note: while `streaming`, an incomplete trailing token
+   * is not treated as an error but returned so `write` can buffer it
+   * and prepend it to the next chunk. This buffered remainder is an
+   * implementation detail of the streaming buffer, not a public API;
+   * outside of that case the return value is `undefined`.
+   *
+   * @param {string} xml
+   * @param {boolean} streaming
+   *
+   * @return {string|undefined} buffered remainder, streaming internal use only
    */
-  function parse(xml) {
+  function parse(xml, streaming = false) {
+
     var elNameCache = null,
-        elNameCacheMatrix = null,
-        nsMatrixStack = isNamespace ? [] : null,
-        nsMatrix = isNamespace ? buildNsMatrix(nsUriToPrefix) : null,
-        _nsMatrix,
-        nodeStack = [],
+        elNameCacheMatrix = null;
+
+    var _nsMatrix,
         anonymousNsCount = 0,
         tagStart = false,
         tagEnd = false,
@@ -671,13 +789,19 @@ export default function Parser(options) {
         i = xml.indexOf('<', j);
       }
 
-      // parse end
+      // no (more) tags found
       if (i === -1) {
+
+        // buffer the remainder for the next chunk
+        if (streaming) {
+          return xml.substring(j);
+        }
+
         if (nodeStack.length) {
           return handleError('unexpected end of file');
         }
 
-        if (j === 0) {
+        if (!rootTagFound) {
           return handleError('missing start tag');
         }
 
@@ -688,6 +812,11 @@ export default function Parser(options) {
         }
 
         return;
+      }
+
+      // remember that we saw the root tag
+      if (!rootTagFound) {
+        rootTagFound = true;
       }
 
       // parse text
@@ -722,6 +851,9 @@ export default function Parser(options) {
         if (q === 91 && xml.substr(i + 3, 6) === 'CDATA[') { // 91 == "["
           j = xml.indexOf(']]>', i);
           if (j === -1) {
+            if (streaming) {
+              return xml.substring(i);
+            }
             return handleError('unclosed cdata');
           }
 
@@ -740,6 +872,9 @@ export default function Parser(options) {
         if (q === 45 && xml.charCodeAt(i + 3) === 45) { // 45 == "-"
           j = xml.indexOf('-->', i);
           if (j === -1) {
+            if (streaming) {
+              return xml.substring(i);
+            }
             return handleError('unclosed comment');
           }
 
@@ -760,6 +895,9 @@ export default function Parser(options) {
       if (w === 63) { // "?"
         j = xml.indexOf('?>', i);
         if (j === -1) {
+          if (streaming) {
+            return xml.substring(i);
+          }
           return handleError('unclosed question');
         }
 
@@ -780,6 +918,9 @@ export default function Parser(options) {
       for (x = i + 1; ; x++) {
         v = xml.charCodeAt(x);
         if (isNaN(v)) {
+          if (streaming) {
+            return xml.substring(i);
+          }
           j = -1;
           return handleError('unclosed tag');
         }

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,0 +1,32 @@
+import {
+  Parser
+} from 'saxen';
+
+import assert from 'node:assert';
+
+
+describe('parser', function() {
+
+  describe('reuse', function() {
+
+    it('should reset state between parses', function() {
+
+      // given
+      var parser = new Parser();
+
+      var openTags = [];
+      parser.on('openTag', function(name) {
+        openTags.push(name);
+      });
+
+      // when
+      parser.parse('<a/>');
+      parser.parse('<b/>');
+
+      // then
+      assert.deepEqual(openTags, [ 'a', 'b' ]);
+    });
+
+  });
+
+});

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,0 +1,683 @@
+import {
+  Parser
+} from 'saxen';
+
+import assert from 'node:assert';
+
+
+/**
+ * Collect all parse events emitted while writing the given
+ * chunks to a streaming parser.
+ *
+ * @param {string[]} chunks
+ * @param {Object} [options]
+ *
+ * @return {{ events: Array, error: Error }}
+ */
+function collect(chunks, options) {
+  var parser = new Parser(options);
+
+  if (options && options.ns) {
+    parser.ns(options.ns);
+  }
+
+  var events = [];
+  var error;
+
+  parser.on('openTag', function(name, attrGetter, decodeEntities) {
+    events.push([ 'openTag', name, attrGetter() ]);
+  });
+  parser.on('closeTag', function(name) {
+    events.push([ 'closeTag', name ]);
+  });
+  parser.on('text', function(value, decodeEntities) {
+    events.push([ 'text', decodeEntities(value) ]);
+  });
+  parser.on('cdata', function(value) {
+    events.push([ 'cdata', value ]);
+  });
+  parser.on('comment', function(value) {
+    events.push([ 'comment', value ]);
+  });
+  parser.on('question', function(value) {
+    events.push([ 'question', value ]);
+  });
+  parser.on('attention', function(value) {
+    events.push([ 'attention', value ]);
+  });
+  parser.on('error', function(err) {
+    error = err;
+  });
+
+  chunks.forEach(function(chunk) {
+    parser.write(chunk);
+  });
+
+  error = parser.end() || error;
+
+  return { events: events, error: error };
+}
+
+
+/**
+ * Collect all parse events emitted while writing the given chunks
+ * to a streaming parser running in proxy mode.
+ *
+ * The element view is cloned per event, as it is only a live view
+ * into the current parser state.
+ *
+ * @param {string[]} chunks
+ * @param {Object} [options]
+ *
+ * @return {{ events: Array, error: Error }}
+ */
+function collectProxy(chunks, options) {
+  var parser = new Parser({ proxy: true });
+
+  if (options && options.ns) {
+    parser.ns(options.ns);
+  }
+
+  var events = [];
+  var error;
+
+  parser.on('openTag', function(el, decodeEntities, selfClosing) {
+    events.push([
+      'openTag',
+      el.name,
+      el.originalName,
+      Object.assign({}, el.attrs),
+      Object.assign({}, el.ns),
+      selfClosing
+    ]);
+  });
+  parser.on('closeTag', function(el) {
+    events.push([ 'closeTag', el.name ]);
+  });
+  parser.on('text', function(value, decodeEntities) {
+    events.push([ 'text', decodeEntities(value) ]);
+  });
+  parser.on('error', function(err) {
+    error = err;
+  });
+
+  chunks.forEach(function(chunk) {
+    parser.write(chunk);
+  });
+
+  error = parser.end() || error;
+
+  return { events: events, error: error };
+}
+
+
+describe('stream', function() {
+
+  describe('#write / #end', function() {
+
+    it('should return the parser from #write', function() {
+
+      // given
+      var parser = new Parser();
+
+      // then
+      assert.strictEqual(parser.write('<root'), parser);
+      assert.strictEqual(parser.write('/>'), parser);
+    });
+
+
+    it('should throw on invalid arg', function() {
+
+      // given
+      var parser = new Parser();
+
+      // then
+      assert.throws(function() {
+        parser.write({});
+      }, /required args <xml=string>/);
+    });
+
+
+    it('should parse XML written as a single chunk', function() {
+
+      // when
+      var result = collect([ '<root>text</root>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'root', {} ],
+        [ 'text', 'text' ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should parse XML written character by character', function() {
+
+      // given
+      var xml = '<root a="1">hi <child/> there</root>';
+
+      // when
+      var result = collect(xml.split(''));
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'root', { a: '1' } ],
+        [ 'text', 'hi ' ],
+        [ 'openTag', 'child', {} ],
+        [ 'closeTag', 'child' ],
+        [ 'text', ' there' ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+  });
+
+
+  describe('chunk boundaries', function() {
+
+    it('should split an open tag', function() {
+
+      // when
+      var result = collect([ '<ro', 'ot', ' a', '="1"', '>', '</root>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'root', { a: '1' } ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should split an attribute value', function() {
+
+      // when
+      var result = collect([ '<root a="va', 'lue"/>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'root', { a: 'value' } ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should split a self-closing tag', function() {
+
+      // when
+      var result = collect([ '<root', '/', '>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'root', {} ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should split a closing tag', function() {
+
+      // when
+      var result = collect([ '<root><', '/', 'root', '>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'root', {} ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should buffer text until the next tag', function() {
+
+      // when
+      var result = collect([ '<root>hel', 'lo wor', 'ld</root>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'root', {} ],
+        [ 'text', 'hello world' ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should not emit text twice on a following incomplete tag', function() {
+
+      // when
+      var result = collect([ '<root>text<chi', 'ld/></root>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'root', {} ],
+        [ 'text', 'text' ],
+        [ 'openTag', 'child', {} ],
+        [ 'closeTag', 'child' ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should split an entity in text', function() {
+
+      // when
+      var result = collect([ '<root>a &am', 'p; b</root>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'root', {} ],
+        [ 'text', 'a & b' ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should split a CDATA section', function() {
+
+      // when
+      var result = collect([ '<root><![CD', 'ATA[a <b> c]', ']></root>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'root', {} ],
+        [ 'cdata', 'a <b> c' ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should split a CDATA section right after "<"', function() {
+
+      // when
+      // split as <|!|[CDATA[...]]> — the marker is not yet known
+      // when only "<" has been written; a ">" inside the section
+      // must not close it prematurely
+      var result = collect([ '<root>', '<', '!', '[CDATA[a > b]]>', '</root>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'root', {} ],
+        [ 'cdata', 'a > b' ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should split a comment', function() {
+
+      // when
+      var result = collect([ '<root><!-- a ', '-- b -->x</root>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'root', {} ],
+        [ 'comment', ' a -- b ' ],
+        [ 'text', 'x' ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should split a comment right after "<"', function() {
+
+      // when
+      // split as <|!|-- ... -->
+      var result = collect([ '<root>', '<', '!', '-- some comment -->', '</root>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'root', {} ],
+        [ 'comment', ' some comment ' ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should split a comment containing ">" right after "<"', function() {
+
+      // when
+      var result = collect([ '<root>', '<', '!-- a > b -->', '</root>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'root', {} ],
+        [ 'comment', ' a > b ' ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should split a processing instruction', function() {
+
+      // when
+      var result = collect([ '<?xml vers', 'ion="1.0"?><root/>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'question', '<?xml version="1.0"?>' ],
+        [ 'openTag', 'root', {} ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should split a processing instruction right after "<"', function() {
+
+      // when
+      // split as <|?|xml ...?>
+      var result = collect([ '<', '?', 'xml version="1.0"?>', '<root/>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'question', '<?xml version="1.0"?>' ],
+        [ 'openTag', 'root', {} ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should split an attention tag', function() {
+
+      // when
+      var result = collect([ '<!DOCT', 'YPE root><root/>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'attention', '<!DOCTYPE root>' ],
+        [ 'openTag', 'root', {} ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should split an attention tag right after "<"', function() {
+
+      // when
+      // split as <|!|DOCTYPE ...>
+      var result = collect([ '<', '!', 'DOCTYPE root>', '<root/>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'attention', '<!DOCTYPE root>' ],
+        [ 'openTag', 'root', {} ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should split leading whitespace before the root', function() {
+
+      // when
+      var result = collect([ '  ', '\n  ', '<root/>' ]);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'root', {} ],
+        [ 'closeTag', 'root' ]
+      ]);
+    });
+
+
+    it('should split namespace declarations', function() {
+
+      // when
+      var result = collect([
+        '<foo:root xmlns:foo="http://', 'foo" foo:a="A"/>'
+      ], {
+        ns: { 'http://foo': 'foo' }
+      });
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'foo:root', { 'xmlns:foo': 'http://foo', 'foo:a': 'A' } ],
+        [ 'closeTag', 'foo:root' ]
+      ]);
+    });
+
+
+    it('should produce the same result regardless of chunking', function() {
+
+      // given
+      var xml =
+        '<root xmlns:x="urn:x">' +
+          '<x:child a="1">hi &amp; bye</x:child>' +
+          '<![CDATA[ raw <data> ]]>' +
+          '<!-- comment -->' +
+        '</root>';
+
+      var options = { ns: { 'urn:x': 'x' } };
+
+      // when
+      var whole = collect([ xml ], options);
+      var perChar = collect(xml.split(''), options);
+
+      // then
+      assert.equal(whole.error, undefined);
+      assert.equal(perChar.error, undefined);
+      assert.deepEqual(perChar.events, whole.events);
+    });
+
+  });
+
+
+  describe('errors', function() {
+
+    it('should report unclosed tag on #end', function() {
+
+      // given
+      var parser = new Parser();
+
+      var error;
+      parser.on('error', function(err) {
+        error = err;
+      });
+
+      // when
+      parser.write('<root');
+
+      // then
+      assert.equal(error, undefined, 'no error while streaming');
+
+      // when
+      var returnError = parser.end();
+
+      // then
+      assert.ok(returnError, 'error returned');
+      assert.equal(returnError.message, 'unclosed tag');
+      assert.strictEqual(error, returnError);
+    });
+
+
+    it('should report unexpected end of file for an open root', function() {
+
+      // when
+      var result = collect([ '<root>', '<child/>' ]);
+
+      // then
+      assert.ok(result.error);
+      assert.equal(result.error.message, 'unexpected end of file');
+    });
+
+
+    it('should report missing start tag for empty input', function() {
+
+      // when
+      var result = collect([ '   ' ]);
+
+      // then
+      assert.ok(result.error);
+      assert.equal(result.error.message, 'missing start tag');
+    });
+
+  });
+
+
+  describe('reuse', function() {
+
+    it('should reset state between streams', function() {
+
+      // given
+      var parser = new Parser();
+
+      var openTags = [];
+      parser.on('openTag', function(name) {
+        openTags.push(name);
+      });
+
+      // when
+      parser.write('<a/>').end();
+      parser.write('<b/>').end();
+
+      // then
+      assert.deepEqual(openTags, [ 'a', 'b' ]);
+    });
+
+
+    it('should throw on #parse while streaming', function() {
+
+      // given
+      var parser = new Parser();
+
+      parser.write('<root>');
+
+      // then
+      assert.throws(function() {
+        parser.parse('<other/>');
+      }, /parse during stream/);
+    });
+
+  });
+
+
+  describe('namespaces + attributes', function() {
+
+    var ns = {
+      ns: {
+        'http://foo': 'foo',
+        'http://bar': 'bar'
+      }
+    };
+
+    it('should parse namespaced attributes split across chunks', function() {
+
+      // given
+      var chunks = [
+        '<root xmlns="http://foo" xmlns:b',
+        'ar="http://bar" bar:aa="A"',
+        ' id="1">hi</root>'
+      ];
+
+      // when
+      var result = collect(chunks, ns);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [ 'openTag', 'foo:root', {
+          'xmlns': 'http://foo',
+          'xmlns:bar': 'http://bar',
+          'bar:aa': 'A',
+          'id': '1'
+        } ],
+        [ 'text', 'hi' ],
+        [ 'closeTag', 'foo:root' ]
+      ]);
+    });
+
+
+    it('should be independent of chunk boundaries', function() {
+
+      // given
+      var xml =
+        '<root xmlns="http://foo" xmlns:bar="http://bar" bar:aa="A" id="1">' +
+          'hi' +
+        '</root>';
+
+      // when
+      var whole = collect([ xml ], ns);
+      var perChar = collect(xml.split(''), ns);
+
+      // then
+      assert.equal(whole.error, undefined);
+      assert.equal(perChar.error, undefined);
+      assert.deepEqual(perChar.events, whole.events);
+    });
+
+  });
+
+
+  describe('proxy mode', function() {
+
+    var ns = { ns: { 'http://foo': 'foo' } };
+
+    it('should expose element view for streamed chunks', function() {
+
+      // given
+      var chunks = [
+        '<root xmlns="http://foo" fo',
+        'o="&quot;" id="1" ',
+        '/>'
+      ];
+
+      // when
+      var result = collectProxy(chunks, ns);
+
+      // then
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.events, [
+        [
+          'openTag',
+          'foo:root',
+          'root',
+          { 'xmlns': 'http://foo', 'foo': '&quot;', 'id': '1' },
+          {
+            'foo': 'foo',
+            'foo$uri': 'http://foo',
+            'xmlns': 'foo',
+            'xmlns$uri': 'http://foo'
+          },
+          true
+        ],
+        [ 'closeTag', 'foo:root' ]
+      ]);
+    });
+
+
+    it('should be independent of chunk boundaries', function() {
+
+      // given
+      var xml = '<root xmlns="http://foo" foo="&quot;" id="1">hi</root>';
+
+      // when
+      var whole = collectProxy([ xml ], ns);
+      var perChar = collectProxy(xml.split(''), ns);
+
+      // then
+      assert.equal(whole.error, undefined);
+      assert.equal(perChar.error, undefined);
+      assert.deepEqual(perChar.events, whole.events);
+    });
+
+  });
+
+});


### PR DESCRIPTION
### Which issue does this PR address?

Closes #3 

---

Puts the parser into streaming mode by invoking `write` (over `parse`) - more chunks can be written, and overall parse must be completed via `end`:

```
var parser = new Parser();

parser.on('openTag', ...);

// stream input data in chunks
parser
  .write('<xml>')
  .write('<child />')
  .write('</xml>')
  .end();
```

